### PR TITLE
Replace path() with path_and_query().as_str()

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -70,7 +70,7 @@ where
                         RequestCapture::Continue => {}
                     }
 
-                    *request.uri_mut() = request.uri().path().parse()?;
+                    *request.uri_mut() = request.uri().path_and_query().as_str().parse()?;
                     // TODO: don't have this unnecessary overhead every time
                     let proxy_connection: HeaderName =
                         HeaderName::from_lowercase(b"proxy-connection")


### PR DESCRIPTION
Closes #23 

I'm also unsure what the purpose of this line is in the first place. As far as I can tell, the URI that proxy clients send to the server does not need to be modified, but I'm not familiar enough with HTTP proxies to say for sure. However, sites that require queries for their API or navigation do not function properly.